### PR TITLE
Remove wakatime reference from description

### DIFF
--- a/flockatime/package.json
+++ b/flockatime/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "flockatime",
 	"displayName": "flockatime",
-  "description": "wakatime clone for bootcamp project",
+  "description": "time tracking bootcamp project",
   "publisher": "bootcamp-ballas",
 	"version": "0.1.0",
 	"engines": {


### PR DESCRIPTION
Just so searching wakatime in the extension menu doesn't bring up two results, which can be confusing.